### PR TITLE
Use node buildpack to enforce its version

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,26 @@
+{
+  "addons": [
+    {
+      "plan": "heroku-postgresql"
+    }
+  ],
+  "buildpacks": [
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-nodejs"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
+    }
+  ],
+  "env": {
+    "SECRET_KEY_BASE": {
+      "generator": "secret"
+    }
+  },
+  "formation": {},
+  "name": "aurora-rails-starter",
+  "scripts": {
+    "postdeploy": "bundle exec rake populate:admin_user"  
+  },
+  "stack": "heroku-18"
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "railsstarter",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": "12.16.1"
+  },
   "scripts": {
     "lint": "eslint --ext js,jsx frontend app/assets",
     "lint-styles": "stylelint frontend/**/* app/assets/**/*",


### PR DESCRIPTION
Our node version was being set by the ruby buildpack. By using the nodejs buildpack first, we can set the node version to what's in the engines field on the `package.json`.

This also allows us to merge #264, because that new update requires a higher node version.