### PR TITLE
Remove useless gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,8 @@ group :test do
   gem "database_cleaner"
   gem "rack_session_access"
   gem "selenium-webdriver"
-  gem "super_diff"
   gem "shoulda-matchers"
+  gem "super_diff"
 end
 
 gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ end
 group :development do
   gem "better_errors"
   gem "foreman"
-  gem "listen", ">= 3.0.5", "< 3.3"
   gem "rubocop"
   gem "rubocop-performance"
   gem "rubocop-rails"
@@ -38,10 +37,9 @@ end
 group :test do
   gem "capybara"
   gem "database_cleaner"
-  gem "differ"
   gem "rack_session_access"
   gem "selenium-webdriver"
-  gem "shoulda-callback-matchers"
+  gem "super_diff"
   gem "shoulda-matchers"
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ end
 group :development do
   gem "better_errors"
   gem "foreman"
+  gem "listen", ">= 3.0.5", "< 3.3"
   gem "rubocop"
   gem "rubocop-performance"
   gem "rubocop-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,6 +336,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   foreman
+  listen (>= 3.0.5, < 3.3)
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
     ast (2.4.0)
+    attr_extras (6.2.3)
     autoprefixer-rails (9.7.4)
       execjs
     bcrypt (3.1.13)
@@ -98,7 +99,6 @@ GEM
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
     diff-lcs (1.3)
-    differ (0.1.2)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -172,6 +172,8 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.5)
       ast (~> 2.4.0)
+    patience_diff (1.1.0)
+      trollop (~> 1.16)
     pg (1.2.3)
     pry (0.13.0)
       coderay (~> 1.1)
@@ -276,8 +278,6 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     semantic_range (2.3.0)
-    shoulda-callback-matchers (1.1.4)
-      activesupport (>= 3)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
     sorcery (0.14.0)
@@ -295,9 +295,14 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    super_diff (0.4.2)
+      attr_extras
+      diff-lcs
+      patience_diff
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    trollop (1.16.2)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
@@ -327,12 +332,10 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   capybara
   database_cleaner
-  differ
   dotenv-rails
   factory_bot_rails
   faker
   foreman
-  listen (>= 3.0.5, < 3.3)
   pg (>= 0.18, < 2.0)
   pry-byebug
   pry-rails
@@ -347,11 +350,11 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   selenium-webdriver
-  shoulda-callback-matchers
   shoulda-matchers
   sorcery
   spring
   spring-watcher-listen (~> 2.0.0)
+  super_diff
   tzinfo-data
   web-console (>= 3.3.0)
   webpacker (~> 5.0.1)


### PR DESCRIPTION
This PR removes useless gems that the start was not using. We want to keep this as slim as possible and any extra functionality should be added on a per-project basis.

Changes:
* Remove `differ` and replace with a better gem `super_diff`
* Remove `shoulda_matchers_callback`. Add to projects if needed. We should avoid using callbacks.
