### PR TITLE
Remove CORS gem and configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,6 @@ gem "administrate"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "pg", ">= 0.18", "< 2.0"
 gem "puma", "~> 4.3"
-gem "rack-cors"
 gem "rails", "~> 6.0.2"
 gem "sorcery"
 gem "webpacker", "~> 5.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,8 +185,6 @@ GEM
     puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.2.2)
-    rack-cors (1.1.1)
-      rack (>= 2.0.0)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -337,7 +335,6 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma (~> 4.3)
-  rack-cors
   rack_session_access
   rails (~> 6.0.2)
   rb-readline

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ If you want more Sorcery modules, check out their documentation and implement it
 
 Administrate is also installed, allowing users with the admin role to create accounts, as user registrations are disabled by default. The admin dashboard is present at `/admin`.
 
+We configure this on `application.rb`, you can also define on `development.rb`, `test.rb` and `production.rb` files. If your API is going to be exclusively
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If you want more Sorcery modules, check out their documentation and implement it
 
 Administrate is also installed, allowing users with the admin role to create accounts, as user registrations are disabled by default. The admin dashboard is present at `/admin`.
 
-We configure this on `application.rb`, you can also define on `development.rb`, `test.rb` and `production.rb` files. If your API is going to be exclusively
+We don't include CORS configuration as this starter is to be used on a single domain. If you need to enable CORS please install and configure the `rack-cors` gem. Even with the default restrictive behavior from Rails you can still make server-to-server requests, and most native mobile apps can still make requests (webview technologies like Ionic and PhoneGap will need CORS).
 
 ## Testing
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,12 +27,5 @@ module RailsStarter
 
     # Don't generate system test files.
     config.generators.system_tests = nil
-
-    config.middleware.insert_before 0, Rack::Cors do
-      allow do
-        origins "*"
-        resource "*", headers: :any, methods: :any
-      end
-    end
   end
 end


### PR DESCRIPTION
We don't need CORS config as the is used in a single domain. If we need we should add CORS back in.

There is no problem is disabling this. It's best to keep the default restrictive behavior of Rails (disable all CORS requests) and when the problem arises we add this in.