### PR TITLE
Add new rules to rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -74,6 +74,15 @@ Style/FrozenStringLiteralComment:
 Style/Lambda:
   EnforcedStyle: literal
 
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
 Metrics/BlockLength:
   Exclude:
     - spec/**/*.rb
@@ -82,3 +91,9 @@ Metrics/BlockLength:
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/**/*.rb
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true


### PR DESCRIPTION
Rubocop was giving us a warning regarding new rules without config values. This fixes it.

These are new rules given the changes to Ruby 2.7. We are still not using that version, but will soon enough.