### PR TITLE
Fix CSRF token integration

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -26,9 +26,6 @@ Rails.application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
-
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :test
 

--- a/frontend/api/setupCsrfToken.js
+++ b/frontend/api/setupCsrfToken.js
@@ -1,0 +1,7 @@
+import redaxios from "redaxios";
+
+export default function setupCsrfToken() {
+  const csrfToken = document.querySelector("meta[name=csrf-token]").content;
+
+  redaxios.defaults.headers = { "X-CSRF-Token": csrfToken };
+}

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -4,9 +4,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import App from "root/components/App";
+import setupCsrfToken from "root/api/setupCsrfToken";
 
 import "./styles/reset.css";
 
 window.addEventListener("DOMContentLoaded", () => {
+  setupCsrfToken();
+
   ReactDOM.render(<App />, document.getElementById("root"));
 });


### PR DESCRIPTION
For some reason **I** disabled CSRF. Perhaps I had drank too much beer that day. So I re-enabled it and made sure Rails requires CSRF tokens even during testing, to stop this from happening in the future.