### PR TITLE
Gerenate a new token on logout

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,7 @@ class SessionsController < ApplicationController
     invalidate_active_sessions! if params[:everywhere] == "true"
     logout
 
-    head :ok
+    render json: session[:_csrf_token]
   end
 
   private

--- a/frontend/api/auth.js
+++ b/frontend/api/auth.js
@@ -1,4 +1,5 @@
 import redaxios from "redaxios";
+import setupCsrfToken from "root/api/setupCsrfToken";
 
 export async function getSession() {
   const response = await redaxios.get("/session");
@@ -14,6 +15,8 @@ export async function login(email, password) {
 
 export async function logout() {
   const response = await redaxios.delete("/session");
+
+  setupCsrfToken(response.data);
 
   return response;
 }

--- a/frontend/api/setupCsrfToken.js
+++ b/frontend/api/setupCsrfToken.js
@@ -1,7 +1,8 @@
 import redaxios from "redaxios";
 
-export default function setupCsrfToken() {
-  const csrfToken = document.querySelector("meta[name=csrf-token]").content;
+export default function setupCsrfToken(token) {
+  const csrfToken =
+    token || document.querySelector("meta[name=csrf-token]").content;
 
   redaxios.defaults.headers = { "X-CSRF-Token": csrfToken };
 }


### PR DESCRIPTION
Why:
* When we logout, sorcery gem calls
[reset_session](https://github.com/Sorcery/sorcery/blob/5c7933c924041d6501a6917e952cc9c949e3ae0f/lib/sorcery/controller.rb#L77)
which cleans out all the objects stored within `session`. This mean
there is no CSRF token in the session after that point
* On top of that, the frontend sets the CSRF token to axios whe the app
loads
* So we need to fix two things:
  * Generate a new csrf token after the session has been cleared out
  * Update axios headers with the new token when the user logs out

What:
* Backend:
  * After calling `logout` in sessions_controller, we generate a new
  token and set it in the current session with `form_authenticity_token`
  * Sends the new token as the response of `DELETE /api/session`
* Frontend:
  * Updating axios header with the new token after successfully loggin
  out
  * Refactoring `setupCsrfToken` so that it doesn't read from the DOM if
  a token is provided via params